### PR TITLE
honest nullable fields

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -21,7 +21,7 @@
   },
   "common": {
     "bufferSize": 90000,
-    "minBufferSize": 2000,
+    "minBufferSize": 1,
     "msgSizeHint": 1000,
     "flushInterval": 5,
     "concurrentParsers": 6,

--- a/conf/tasks/daily_request.json
+++ b/conf/tasks/daily_request.json
@@ -5,7 +5,7 @@
   "earliest": true,
   "consumerGroup": "group",
   "parser": "gjson_extend",
-  "clickhouse": "ch",
+  "clickhouse": "ch1",
   "tableName": "daily",
   "dims": [
     {
@@ -25,6 +25,5 @@
     }
   ],
   "@desc_of_exclude_columns": "this columns will be excluded by insert SQL ",
-  "excludeColumns": [],
-  "bufferSize": 2
+  "excludeColumns": []
 }

--- a/conf/tasks/logstash_sample.json
+++ b/conf/tasks/logstash_sample.json
@@ -1,23 +1,21 @@
-{	
-
+{
 	"name" : "logstash_sample",
-
 	"kafka": "kfk1",
 	"topic": "logstash",
 	"consumerGroup" : "logstash_sample_ck",
-
 	"parser" : "json",
 	"clickhouse" : "ch1",
-		
 	"tableName" : "logstash",
-	
 	"dims" : [
 		{"name" : "date" , "type" : "ElasticDateTime"},
 		{"name" : "level" , "type" : "String"},
-		{"name" : "message" , "type" : "String"}
-	],
-
-	"bufferSize" : 1,
-	"num" : 1
-} 
+		{"name" : "message" , "type" : "String"},
+		{"name" : "str_nullable" , "type" : "Nullable(String)"},
+		{"name" : "num" , "type" : "Int64"},
+		{"name" : "num_nullable" , "type" : "Nullable(Int64)"},
+		{"name" : "fnum" , "type" : "Float64"},
+		{"name" : "fnum_nullable" , "type" : "Nullable(Float64)"},
+		{"name" : "date_nullable" , "type" : "Nullable(ElasticDateTime)"}
+	]
+}
 

--- a/model/metric.go
+++ b/model/metric.go
@@ -15,21 +15,19 @@ limitations under the License.
 
 package model
 
-import (
-	"time"
-)
+import "time"
 
 // Metric interface for metric collection
 type Metric interface {
 	Get(key string) interface{}
-	GetString(key string) string
+	GetString(key string, nullable bool) interface{}
 	GetArray(key string, t string) interface{}
-	GetFloat(key string) float64
-	GetInt(key string) int64
+	GetFloat(key string, nullable bool) interface{}
+	GetInt(key string, nullable bool) interface{}
 	GetDate(key string) time.Time
 	GetDateTime(key string) time.Time
 	GetDateTime64(key string) time.Time
-	GetElasticDateTime(key string) int64
+	GetElasticDateTime(key string, nullable bool) interface{}
 }
 
 // DimMetrics

--- a/parser/csv.go
+++ b/parser/csv.go
@@ -66,7 +66,8 @@ func (c *CsvMetric) Get(key string) interface{} {
 }
 
 // GetString get the value as string
-func (c *CsvMetric) GetString(key string) string {
+func (c *CsvMetric) GetString(key string, nullable bool) interface{} {
+	_ = nullable // nullable can not be supported with csv
 	for i, k := range c.titles {
 		if k == key && i < len(c.values) {
 			return c.values[i]
@@ -76,7 +77,8 @@ func (c *CsvMetric) GetString(key string) string {
 }
 
 // GetFloat returns the value as float
-func (c *CsvMetric) GetFloat(key string) float64 {
+func (c *CsvMetric) GetFloat(key string, nullable bool) interface{} {
+	_ = nullable // nullable can not be supported with csv
 	for i, k := range c.titles {
 		if k == key && i < len(c.values) {
 			n, _ := strconv.ParseFloat(c.values[i], 64)
@@ -87,7 +89,8 @@ func (c *CsvMetric) GetFloat(key string) float64 {
 }
 
 // GetInt returns int
-func (c *CsvMetric) GetInt(key string) int64 {
+func (c *CsvMetric) GetInt(key string, nullable bool) interface{} {
+	_ = nullable // nullable can not be supported with csv
 	for i, k := range c.titles {
 		if k == key && i < len(c.values) {
 			n, _ := strconv.ParseInt(c.values[i], 10, 64)
@@ -103,25 +106,26 @@ func (c *CsvMetric) GetArray(key string, t string) interface{} {
 }
 
 func (c *CsvMetric) GetDate(key string) (t time.Time) {
-	val := c.GetString(key)
+	val := c.GetString(key, false).(string)
 	t, _ = time.Parse(c.tsLayout[0], val)
 	return
 }
 
 func (c *CsvMetric) GetDateTime(key string) (t time.Time) {
-	val := c.GetString(key)
+	val := c.GetString(key, false).(string)
 	t, _ = time.Parse(c.tsLayout[1], val)
 	return
 }
 
 func (c *CsvMetric) GetDateTime64(key string) (t time.Time) {
-	val := c.GetString(key)
+	val := c.GetString(key, false).(string)
 	t, _ = time.Parse(c.tsLayout[2], val)
 	return
 }
 
-func (c *CsvMetric) GetElasticDateTime(key string) int64 {
-	val := c.GetString(key)
+func (c *CsvMetric) GetElasticDateTime(key string, nullable bool) interface{} {
+	_ = nullable // nullable can not be supported with csv
+	val := c.GetString(key, false).(string)
 	t, _ := time.Parse(time.RFC3339, val)
 
 	return t.Unix()

--- a/parser/gjson.go
+++ b/parser/gjson.go
@@ -41,8 +41,13 @@ func (c *GjsonMetric) Get(key string) interface{} {
 	return gjson.Get(c.raw, key).Value()
 }
 
-func (c *GjsonMetric) GetString(key string) string {
-	return gjson.Get(c.raw, key).String()
+func (c *GjsonMetric) GetString(key string, nullable bool) interface{} {
+	r := gjson.Get(c.raw, key)
+	if nullable && !r.Exists() {
+		return nil
+	}
+
+	return r.String()
 }
 
 func (c *GjsonMetric) GetArray(key string, t string) interface{} {
@@ -75,43 +80,54 @@ func (c *GjsonMetric) GetArray(key string, t string) interface{} {
 	}
 }
 
-func (c *GjsonMetric) GetFloat(key string) float64 {
-	return gjson.Get(c.raw, key).Float()
+func (c *GjsonMetric) GetFloat(key string, nullable bool) interface{} {
+	r := gjson.Get(c.raw, key)
+	if nullable && !r.Exists() {
+		return nil
+	}
+	return r.Float()
 }
 
-func (c *GjsonMetric) GetInt(key string) int64 {
-	return gjson.Get(c.raw, key).Int()
+func (c *GjsonMetric) GetInt(key string, nullable bool) interface{} {
+	r := gjson.Get(c.raw, key)
+	if nullable && !r.Exists() {
+		return nil
+	}
+	return r.Int()
 }
 
 func (c *GjsonMetric) GetDate(key string) (t time.Time) {
-	val := c.GetString(key)
+	val := gjson.Get(c.raw, key).String()
 	t, _ = time.Parse(c.tsLayout[0], val)
 	return
 }
 
 func (c *GjsonMetric) GetDateTime(key string) (t time.Time) {
-	if v := c.GetFloat(key); v != 0 {
+	if v := gjson.Get(c.raw, key).Float(); v != 0 {
 		return time.Unix(int64(v), int64(v*1e9)%1e9)
 	}
 
-	val := c.GetString(key)
+	val := gjson.Get(c.raw, key).String()
 	t, _ = time.Parse(c.tsLayout[1], val)
 	return
 }
 
 func (c *GjsonMetric) GetDateTime64(key string) (t time.Time) {
-	if v := c.GetFloat(key); v != 0 {
+	if v := gjson.Get(c.raw, key).Float(); v != 0 {
 		return time.Unix(int64(v), int64(v*1e9)%1e9)
 	}
 
-	val := c.GetString(key)
+	val := gjson.Get(c.raw, key).String()
 	t, _ = time.Parse(c.tsLayout[2], val)
 	return
 }
 
-func (c *GjsonMetric) GetElasticDateTime(key string) int64 {
-	val := c.GetString(key)
-	t, _ := time.Parse(time.RFC3339, val)
+func (c *GjsonMetric) GetElasticDateTime(key string, nullable bool) interface{} {
+	r := gjson.Get(c.raw, key)
+	if nullable && !r.Exists() {
+		return nil
+	}
 
+	t, _ := time.Parse(time.RFC3339, r.String())
 	return t.Unix()
 }

--- a/parser/gjson_extend.go
+++ b/parser/gjson_extend.go
@@ -16,6 +16,7 @@ limitations under the License.
 package parser
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -86,9 +87,14 @@ func (c *GjsonExtendMetric) Get(key string) interface{} {
 	return c.mp[key]
 }
 
-func (c *GjsonExtendMetric) GetString(key string) string {
+func (c *GjsonExtendMetric) GetString(key string, nullable bool) interface{} {
 	//判断object
 	val := c.mp[key]
+
+	if val == nil && nullable {
+		return nil
+	}
+
 	if val == nil {
 		return ""
 	}
@@ -146,8 +152,11 @@ func (c *GjsonExtendMetric) GetArray(key string, t string) interface{} {
 	}
 }
 
-func (c *GjsonExtendMetric) GetFloat(key string) float64 {
+func (c *GjsonExtendMetric) GetFloat(key string, nullable bool) interface{} {
 	val := c.mp[key]
+	if val == nil && nullable {
+		return nil
+	}
 	if val == nil {
 		return 0
 	}
@@ -159,8 +168,12 @@ func (c *GjsonExtendMetric) GetFloat(key string) float64 {
 	}
 }
 
-func (c *GjsonExtendMetric) GetInt(key string) int64 {
+func (c *GjsonExtendMetric) GetInt(key string, nullable bool) interface{} {
 	val := c.mp[key]
+	if val == nil && nullable {
+		return nil
+	}
+
 	if val == nil {
 		return 0
 	}
@@ -173,34 +186,37 @@ func (c *GjsonExtendMetric) GetInt(key string) int64 {
 }
 
 func (c *GjsonExtendMetric) GetDate(key string) (t time.Time) {
-	val := c.GetString(key)
+	val := fmt.Sprintf("%v", c.GetString(key, false))
+
 	t, _ = time.Parse(c.tsLayout[0], val)
 	return
 }
 
 func (c *GjsonExtendMetric) GetDateTime(key string) (t time.Time) {
-	if v := c.GetFloat(key); v != 0 {
+	if v := c.GetFloat(key, false).(float64); v != 0 {
 		return time.Unix(int64(v), int64(v*1e9)%1e9)
 	}
 
-	val := c.GetString(key)
+	val := c.GetString(key, false).(string)
 	t, _ = time.Parse(c.tsLayout[1], val)
 	return
 }
 
 func (c *GjsonExtendMetric) GetDateTime64(key string) (t time.Time) {
-	if v := c.GetFloat(key); v != 0 {
+	if v := c.GetFloat(key, false).(float64); v != 0 {
 		return time.Unix(int64(v), int64(v*1e9)%1e9)
 	}
 
-	val := c.GetString(key)
+	val := c.GetString(key, false).(string)
 	t, _ = time.Parse(c.tsLayout[2], val)
 	return
 }
 
-func (c *GjsonExtendMetric) GetElasticDateTime(key string) int64 {
-	val := c.GetString(key)
-	t, _ := time.Parse(time.RFC3339, val)
-
+func (c *GjsonExtendMetric) GetElasticDateTime(key string, nullable bool) interface{} {
+	val := c.GetString(key, nullable)
+	if val == nil {
+		return nil
+	}
+	t, _ := time.Parse(time.RFC3339, val.(string))
 	return t.Unix()
 }

--- a/parser/gjson_extend_test.go
+++ b/parser/gjson_extend_test.go
@@ -13,8 +13,29 @@ func TestGjsonExtendInt(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected int64 = 1536813227
-	result := metric.GetInt("its")
+	result := metric.GetInt("its", false).(int64)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendIntNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int = 0
+	result := metric.GetInt("its_not_exist", false).(int)
+	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendIntNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetInt("its_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonExtendArrayInt(t *testing.T) {
@@ -37,8 +58,29 @@ func TestGjsonExtendStr(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected string = "ws"
-	result := metric.GetString("channel")
+	result := metric.GetString("channel", false).(string)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendStrNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected string = ""
+	result := metric.GetString("channel_not_exist", false).(string)
+	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendStrNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetString("channel_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonExtendArrayString(t *testing.T) {
@@ -61,8 +103,29 @@ func TestGjsonExtendFloat(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected float64 = 0.11
-	result := metric.GetFloat("percent")
+	result := metric.GetFloat("percent", false).(float64)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendFloatNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int = 0
+	result := metric.GetFloat("percent_not_exist", false).(int)
+	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendFloatNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetFloat("percent_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonExtendArrayFloat(t *testing.T) {
@@ -87,6 +150,27 @@ func TestGjsonExtendElasticDateTime(t *testing.T) {
 	// {"date": "2019-12-16T12:10:30Z"}
 	// TZ=UTC date -d @1576498230 => Mon 16 Dec 2019 12:10:30 PM UTC
 	var expected int64 = 1576498230
-	result := metric.GetElasticDateTime("date")
+	result := metric.GetElasticDateTime("date", false).(int64)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendElasticDateTimeNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int64 = -62135596800
+	result := metric.GetElasticDateTime("date_not_exist", false).(int64)
+	assert.Equal(t, result, expected)
+}
+
+func TestGjsonExtendElasticDateTimeNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetElasticDateTime("date_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }

--- a/parser/gjson_test.go
+++ b/parser/gjson_test.go
@@ -13,8 +13,28 @@ func TestGjsonInt(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected int64 = 1536813227
-	result := metric.GetInt("its")
+	result := metric.GetInt("its", false).(int64)
 	assert.Equal(t, result, expected)
+}
+func TestGjsonIntNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int = 0
+	result := metric.GetInt("its_not_exist", false).(int)
+	assert.Equal(t, expected, result)
+}
+
+func TestGjsonIntNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetInt("its_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonArrayInt(t *testing.T) {
@@ -37,8 +57,27 @@ func TestGjsonStr(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected string = "ws"
-	result := metric.GetString("channel")
+	result := metric.GetString("channel", false).(string)
 	assert.Equal(t, result, expected)
+}
+func TestGjsonStrNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected string = ""
+	result := metric.GetString("channel_not_exist", false).(string)
+	assert.Equal(t, result, expected)
+}
+func TestGjsonStrNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetString("channel_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonArrayString(t *testing.T) {
@@ -61,8 +100,28 @@ func TestGjsonFloat(t *testing.T) {
 	metric, _ := parser.Parse(jsonSample)
 
 	var expected float64 = 0.11
-	result := metric.GetFloat("percent")
+	result := metric.GetFloat("percent", false).(float64)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonFloatNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int = 0
+	result := metric.GetFloat("percent_not_exist", false).(int)
+	assert.Equal(t, result, expected)
+}
+func TestGjsonFloatNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetFloat("percent_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }
 
 func TestGjsonArrayFloat(t *testing.T) {
@@ -87,6 +146,27 @@ func TestGjsonElasticDateTime(t *testing.T) {
 	// {"date": "2019-12-16T12:10:30Z"}
 	// TZ=UTC date -d @1576498230 => Mon 16 Dec 2019 12:10:30 PM UTC
 	var expected int64 = 1576498230
-	result := metric.GetElasticDateTime("date")
+	result := metric.GetElasticDateTime("date", false).(int64)
 	assert.Equal(t, result, expected)
+}
+
+func TestGjsonElasticDateTimeNullableFalse(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	var expected int64 = -62135596800
+	result := metric.GetElasticDateTime("date_not_exist", false).(int64)
+	assert.Equal(t, result, expected)
+}
+
+func TestGjsonElasticDateTimeNullableTrue(t *testing.T) {
+	pp := NewParserPool("gjson_extend", nil, "", DefaultTSLayout)
+	parser := pp.Get()
+	defer pp.Put(parser)
+	metric, _ := parser.Parse(jsonSample)
+
+	result := metric.GetElasticDateTime("date_not_exist", true)
+	assert.Nil(t, result, "err should be nothing")
 }


### PR DESCRIPTION
implemented for string,int,float,ElasticDateTime

So if a field does not exist in JSON but the field type is Nullable 
then instead of the default value, we will ingest NULL
